### PR TITLE
Add `unzip-and-clean.sh` to find and extract large assets automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ The simulator can be exploited by the users (particularly targeting students and
       $ git clone --single-branch --branch AutoDRIVE-Simulator https://github.com/Tinker-Twins/AutoDRIVE.git
       ```
     - Unzip source files larger than 100 MB:
-      > ***Note:*** *This step needs to be done prior to opening the project within Unity, so that the pointers within original `.meta` files are preserved (read more [here](https://docs.unity3d.com/2022.3/Documentation/Manual/AssetMetadata.html)). You may delete the `*.zip` and `*.zip.meta` files after the unzipping operation.*
+      > ***Note:*** *This step needs to be done prior to opening the project within Unity, so that the pointers within original `.meta` files are preserved (read more [here](https://docs.unity3d.com/2022.3/Documentation/Manual/AssetMetadata.html)). After unzipping, you may clean up the `*.zip` and `*.zip.meta` files manually, or run `tools/unzip-and-clean.sh` to do this repository initialization steps automatically.*
 
     - Launch Unity Hub and select `ADD` project button. Navigate to the download directory and select the parent folder of the `AutoDRIVE` repository.
   

--- a/tools/unzip-and-clean.sh
+++ b/tools/unzip-and-clean.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Usage:
+#   ./scripts/unzip_and_clean.sh [root_dir]
+# Unzips every .zip under the root (default: repo root), then deletes the .zip
+# and matching .zip.meta so Unity only tracks the extracted assets.
+
+ROOT="${1:-.}"
+
+if ! command -v unzip >/dev/null 2>&1; then
+  echo "unzip is required but not installed" >&2
+  exit 1
+fi
+
+if [ ! -d "$ROOT" ]; then
+  echo "Root directory not found: $ROOT" >&2
+  exit 1
+fi
+
+while IFS= read -r -d '' zip_path; do
+  target_dir=$(dirname "$zip_path")
+  echo "Unzipping: $zip_path"
+  unzip -nq "$zip_path" -d "$target_dir"
+
+  echo "Removing archive: $zip_path"
+  rm -f "$zip_path"
+
+  meta_path="${zip_path}.meta"
+  if [ -f "$meta_path" ]; then
+    echo "Removing meta: $meta_path"
+    rm -f "$meta_path"
+  fi
+done < <(find "$ROOT" -type f -name '*.zip' -print0)
+
+echo "Done."


### PR DESCRIPTION
This PR makes it easy to follow the README for installing the AutoDRIVE Simulator from source.
There is a step to unzip the files (>100 MB) that couldn't be pushed because of GitHub's size limit.
Finding those `.zip` files and cleaning up the `.zip/.zip.meta` files can be a hassle for people who don't know exactly which `.zip` files need to be extracted and where they're located.

**Usage:**
```bash
$ git clone autodrive-simulator
$ cd autodrive-simulator
$ find . -name '*.zip' # find how many zip files exist
$ tools/unzip-and-clean.sh
$ git status # check the unzipped files and the cleaned .zip/.zip.meta files.
```