### PR TITLE
Improve H2H LapTimer and collision recovery behavior

### DIFF
--- a/Assets/Scripts/DataRecorder.cs
+++ b/Assets/Scripts/DataRecorder.cs
@@ -157,21 +157,23 @@ public class DataRecorder : MonoBehaviour
         isRecording = false;
         isSaving = false;
         RecordStatus.text = "Record Data";
-        // Temporary render textures for all vehicles except the first one (first vehicle will render to GUI)
-        if(FrontCameras.Length != 0)
-        {
-            for(int i=1;i<FrontCameras.Length;i++)
-            {
-                FrontCameras[i].targetTexture = new RenderTexture(1280, 720, 16, RenderTextureFormat.ARGB32);
-            }
-        }
-        if(RearCameras.Length != 0)
-        {
-            for(int i=1;i<RearCameras.Length;i++)
-            {
-                RearCameras[i].targetTexture = new RenderTexture(1280, 720, 16, RenderTextureFormat.ARGB32);
-            }
-        }
+        // Keep the RenderTexture assigned in each scene/prefab so all vehicle camera
+        // images use their configured resolution. Overriding only cameras after V1
+        // made V2+ record larger images than V1.
+        // if(FrontCameras.Length != 0)
+        // {
+        //     for(int i=1;i<FrontCameras.Length;i++)
+        //     {
+        //         FrontCameras[i].targetTexture = new RenderTexture(1280, 720, 16, RenderTextureFormat.ARGB32);
+        //     }
+        // }
+        // if(RearCameras.Length != 0)
+        // {
+        //     for(int i=1;i<RearCameras.Length;i++)
+        //     {
+        //         RearCameras[i].targetTexture = new RenderTexture(1280, 720, 16, RenderTextureFormat.ARGB32);
+        //     }
+        // }
         // Create CSV files and directories for storing data and camera frames of all vehicles
         VehicleDataFileNames = new string[VehicleControllers.Length + AutomobileControllers.Length];
         VehicleCameraDirectories = new string[VehicleControllers.Length + AutomobileControllers.Length];

--- a/Assets/Scripts/LapTimer.cs
+++ b/Assets/Scripts/LapTimer.cs
@@ -49,8 +49,9 @@ public class LapTimer : MonoBehaviour
         }
         else if (collider.tag == "Checkpoint" && !CheckpointFlag)
         {
+            CurrentCheckpoint = GetCheckpointIndex(collider.transform);
+            if (CurrentCheckpoint < 0) return;
             CheckpointFlag = true;
-            CurrentCheckpoint = int.Parse(collider.name);
             if (CurrentCheckpoint == PreviousCheckpoint+1) CheckpointCount = CurrentCheckpoint;
         }
     }
@@ -82,6 +83,16 @@ public class LapTimer : MonoBehaviour
     public void Start()
     {
         VehicleRigidbody = gameObject.GetComponent<Rigidbody>();
+    }
+
+    private int GetCheckpointIndex(Transform checkpoint)
+    {
+        for (int i = 0; i < Checkpoints.Length; i++)
+        {
+            if (Checkpoints[i] == checkpoint) return i;
+        }
+
+        return -1;
     }
 
     private void Update()

--- a/Assets/Scripts/LapTimer.cs
+++ b/Assets/Scripts/LapTimer.cs
@@ -27,10 +27,69 @@ public class LapTimer : MonoBehaviour
     private Transform SavedCheckpoint; // Transform of latest saved checkpoint
     private bool FinishLineFlag = false; // Finish line flag
     private bool CheckpointFlag = false; // Checkpoint flag
+    private int IgnoreRacetrackRespawnUntilFrame = -1;
+    private bool IgnoreVehicleCollisionAfterRespawn = false;
+    private Vector3 VehicleCollisionRespawnPosition;
+    private long VehicleCollisionGracePairKey = -1;
+    private const float VehicleCollisionRespawnOffsetMultiplier = 1.0f;
+    private const float VehicleCollisionGraceExitDistanceMultiplier = 4.0f;
+    private static Dictionary<long, int> vehicleCollisionFrames = new Dictionary<long, int>();
 
     void OnCollisionEnter(Collision collision)
     {
-        if (collision.collider.name == RacetrackName) Respawn(); // Collision detected with racetrack
+        LapTimer otherVehicle = collision.collider.GetComponentInParent<LapTimer>();
+        if (otherVehicle != null && otherVehicle != this)
+        {
+            UpdateVehicleCollisionGrace();
+            otherVehicle.UpdateVehicleCollisionGrace();
+            long collisionPairKey = GetCollisionPairKey(this, otherVehicle);
+            if (IsIgnoringVehicleCollisionWith(collisionPairKey) && otherVehicle.IsIgnoringVehicleCollisionWith(collisionPairKey))
+            {
+                return;
+            }
+
+            int lastCollisionFrame;
+            if (vehicleCollisionFrames.TryGetValue(collisionPairKey, out lastCollisionFrame) && lastCollisionFrame == Time.frameCount)
+            {
+                return;
+            }
+
+            vehicleCollisionFrames[collisionPairKey] = Time.frameCount;
+            RespawnCollisionPairSideBySide(this, otherVehicle);
+            return;
+        }
+
+        if (collision.collider.name == RacetrackName && Time.frameCount > IgnoreRacetrackRespawnUntilFrame) Respawn(); // Collision detected with racetrack
+    }
+
+    private static long GetCollisionPairKey(LapTimer first, LapTimer second)
+    {
+        int firstID = first.GetInstanceID();
+        int secondID = second.GetInstanceID();
+        int minID = Mathf.Min(firstID, secondID);
+        int maxID = Mathf.Max(firstID, secondID);
+
+        return ((long)minID << 32) ^ (uint)maxID;
+    }
+
+    private static void RespawnCollisionPairSideBySide(LapTimer first, LapTimer second)
+    {
+        bool firstOnLeft = first.GetInstanceID() < second.GetInstanceID();
+        int firstRespawnCheckpointCount = first.GetEffectiveRespawnCheckpointCount();
+        int secondRespawnCheckpointCount = second.GetEffectiveRespawnCheckpointCount();
+        int firstProgress = first.GetEffectiveRespawnProgress(firstRespawnCheckpointCount);
+        int secondProgress = second.GetEffectiveRespawnProgress(secondRespawnCheckpointCount);
+        LapTimer leadingVehicle = firstProgress >= secondProgress ? first : second;
+        int respawnCheckpointCount = leadingVehicle == first ? firstRespawnCheckpointCount : secondRespawnCheckpointCount;
+        Transform respawnCheckpoint = leadingVehicle.Checkpoints[respawnCheckpointCount%leadingVehicle.Checkpoints.Length];
+        float lateralOffset = Mathf.Max(
+            first.GetVehicleWidth(respawnCheckpoint.right),
+            second.GetVehicleWidth(respawnCheckpoint.right)
+        ) * VehicleCollisionRespawnOffsetMultiplier;
+
+        long collisionPairKey = GetCollisionPairKey(first, second);
+        first.RespawnWithLateralOffset(respawnCheckpointCount, respawnCheckpoint, firstOnLeft ? -lateralOffset : lateralOffset, collisionPairKey);
+        second.RespawnWithLateralOffset(respawnCheckpointCount, respawnCheckpoint, firstOnLeft ? lateralOffset : -lateralOffset, collisionPairKey);
     }
 
     // Reset lap time and update lap count when crossing start line
@@ -64,7 +123,7 @@ public class LapTimer : MonoBehaviour
         PreviousCheckpoint = CurrentCheckpoint;
     }
 
-    void Respawn()
+    public void Respawn()
     {
         // Reset momentum
         VehicleRigidbody.velocity = Vector3.zero;
@@ -79,6 +138,95 @@ public class LapTimer : MonoBehaviour
 
         // Update clooision flag and count
         CollisionCount = CollisionCount + 1; // Update collision count
+    }
+
+    private void RespawnWithLateralOffset(int checkpointCount, Transform respawnCheckpoint, float lateralOffset, long collisionPairKey)
+    {
+        IgnoreRacetrackRespawnUntilFrame = Time.frameCount + 2;
+        VehicleRigidbody.velocity = Vector3.zero;
+        VehicleRigidbody.angularVelocity = Vector3.zero;
+
+        CheckpointCount = checkpointCount;
+        CurrentCheckpoint = checkpointCount%Checkpoints.Length;
+        PreviousCheckpoint = CurrentCheckpoint;
+        SavedCheckpoint = respawnCheckpoint;
+        gameObject.transform.position = SavedCheckpoint.position + SavedCheckpoint.right * lateralOffset;
+        gameObject.transform.rotation = SavedCheckpoint.rotation;
+        IgnoreVehicleCollisionAfterRespawn = true;
+        VehicleCollisionRespawnPosition = gameObject.transform.position;
+        VehicleCollisionGracePairKey = collisionPairKey;
+
+        CollisionCount = CollisionCount + 1;
+    }
+
+    private int GetEffectiveRespawnCheckpointCount()
+    {
+        if (CheckpointCount == 0 && PreviousCheckpoint > 0) return PreviousCheckpoint;
+        return CheckpointCount;
+    }
+
+    private int GetEffectiveRespawnProgress(int respawnCheckpointCount)
+    {
+        return LapCount * Checkpoints.Length + respawnCheckpointCount;
+    }
+
+    private float GetVehicleWidth(Vector3 lateralDirection)
+    {
+        float controllerWidth = GetControllerVehicleWidth();
+        if (controllerWidth > 0.0f) return controllerWidth;
+
+        return GetColliderVehicleWidth(lateralDirection);
+    }
+
+    private float GetControllerVehicleWidth()
+    {
+        VehicleController vehicleController = GetComponent<VehicleController>();
+        if (vehicleController != null) return vehicleController.TrackWidth / 1000.0f;
+
+        AutomobileController automobileController = GetComponent<AutomobileController>();
+        if (automobileController != null) return automobileController.TrackWidth;
+
+        return 0.0f;
+    }
+
+    private float GetColliderVehicleWidth(Vector3 lateralDirection)
+    {
+        Collider[] colliders = GetComponentsInChildren<Collider>();
+        if (colliders.Length == 0) return 0.0f;
+
+        lateralDirection.Normalize();
+        bool hasBounds = false;
+        float minProjection = 0.0f;
+        float maxProjection = 0.0f;
+
+        for (int i = 0; i < colliders.Length; i++)
+        {
+            if (colliders[i].isTrigger) continue;
+
+            Bounds bounds = colliders[i].bounds;
+            Vector3 center = bounds.center;
+            Vector3 extents = bounds.extents;
+            float centerProjection = Vector3.Dot(center, lateralDirection);
+            float projectedExtent = Mathf.Abs(lateralDirection.x) * extents.x
+                + Mathf.Abs(lateralDirection.y) * extents.y
+                + Mathf.Abs(lateralDirection.z) * extents.z;
+
+            float colliderMinProjection = centerProjection - projectedExtent;
+            float colliderMaxProjection = centerProjection + projectedExtent;
+            if (!hasBounds)
+            {
+                minProjection = colliderMinProjection;
+                maxProjection = colliderMaxProjection;
+                hasBounds = true;
+            }
+            else
+            {
+                minProjection = Mathf.Min(minProjection, colliderMinProjection);
+                maxProjection = Mathf.Max(maxProjection, colliderMaxProjection);
+            }
+        }
+
+        return hasBounds ? maxProjection - minProjection : 0.0f;
     }
 
     public void Start()
@@ -103,6 +251,8 @@ public class LapTimer : MonoBehaviour
 
     private void Update()
     {
+        UpdateVehicleCollisionGrace();
+
         // Update current lap time on GUI
         if (LapTime < 10) txtLapTime.text = "0" + LapTime.ToString("f1");
         else txtLapTime.text = LapTime.ToString("f1");
@@ -119,6 +269,23 @@ public class LapTimer : MonoBehaviour
         else txtBestLap.text = BestLapTime.ToString("f1");
         // Update collision count on GUI
         txtCollisionCount.text = CollisionCount.ToString();
+    }
+
+    private void UpdateVehicleCollisionGrace()
+    {
+        if (!IgnoreVehicleCollisionAfterRespawn) return;
+
+        float graceExitDistance = GetVehicleWidth(transform.right) * VehicleCollisionGraceExitDistanceMultiplier;
+        if (Vector3.Distance(transform.position, VehicleCollisionRespawnPosition) > graceExitDistance)
+        {
+            IgnoreVehicleCollisionAfterRespawn = false;
+            VehicleCollisionGracePairKey = -1;
+        }
+    }
+
+    private bool IsIgnoringVehicleCollisionWith(long collisionPairKey)
+    {
+        return IgnoreVehicleCollisionAfterRespawn && VehicleCollisionGracePairKey == collisionPairKey;
     }
 
     public void FixedUpdate()

--- a/Assets/Scripts/LapTimer.cs
+++ b/Assets/Scripts/LapTimer.cs
@@ -36,8 +36,9 @@ public class LapTimer : MonoBehaviour
     // Reset lap time and update lap count when crossing start line
     private void OnTriggerEnter(Collider collider)
     {   
-        // Redundancy in checking lap completion (Either Finish Line A or Finish Line B are NOT checkpoints)
-        if ((collider.tag == "Finish Line A") && !FinishLineFlag && (CheckpointCount >= (Checkpoints.Length-1)))
+        // Count a completed lap when the vehicle crosses either finish line after
+        // traversing the full checkpoint sequence assigned to this LapTimer.
+        if (IsFinishLine(collider) && !FinishLineFlag && (CheckpointCount >= (Checkpoints.Length-1)))
         {
             // Update only on positive edge of trigger
             LapCount += 1;
@@ -93,6 +94,11 @@ public class LapTimer : MonoBehaviour
         }
 
         return -1;
+    }
+
+    private bool IsFinishLine(Collider collider)
+    {
+        return collider.tag == "Finish Line A" || collider.tag == "Finish Line B";
     }
 
     private void Update()

--- a/Assets/Scripts/Socket.cs
+++ b/Assets/Scripts/Socket.cs
@@ -55,21 +55,23 @@ public class Socket : MonoBehaviour
         socket.On("connect", OnConnect); // Declare connection event `connect` and corresponding event handler `OnConnect`
         socket.On("Bridge", OnBridge); // Declare event `Bridge` and corresponding event handler `OnBridge`
         socket.On("disconnect", OnDisconnect); // Declare disconnection event `disconnect` and corresponding event handler `OnDisconnect`
-        // Temporary render textures for all vehicles except the first one (first vehicle will render to GUI)
-        if(FrontCameras.Length != 0)
-        {
-            for(int i=1;i<FrontCameras.Length;i++)
-            {
-                FrontCameras[i].targetTexture = new RenderTexture(1280, 720, 16, RenderTextureFormat.ARGB32);
-            }
-        }
-        if(RearCameras.Length != 0)
-        {
-            for(int i=1;i<RearCameras.Length;i++)
-            {
-                RearCameras[i].targetTexture = new RenderTexture(1280, 720, 16, RenderTextureFormat.ARGB32);
-            }
-        }
+        // Keep the RenderTexture assigned in each scene/prefab so all vehicle camera
+        // images use their configured resolution. Overriding only cameras after V1
+        // made V2+ publish larger images than V1.
+        // if(FrontCameras.Length != 0)
+        // {
+        //     for(int i=1;i<FrontCameras.Length;i++)
+        //     {
+        //         FrontCameras[i].targetTexture = new RenderTexture(1280, 720, 16, RenderTextureFormat.ARGB32);
+        //     }
+        // }
+        // if(RearCameras.Length != 0)
+        // {
+        //     for(int i=1;i<RearCameras.Length;i++)
+        //     {
+        //         RearCameras[i].targetTexture = new RenderTexture(1280, 720, 16, RenderTextureFormat.ARGB32);
+        //     }
+        // }
     }
 
     void OnConnect(SocketIOEvent obj)


### PR DESCRIPTION
first 3 commits are bug fix in H2H mode
last commit is applying the respawning behavior that put two cars side by side at the last check point near by the collision point instead of respawning two cars on different last check point.

(In case of using AutoDRIVE RCT, the penalty is given to faulty car by filtering the steer/trottle command for N seconds so that the victim car can take the compensation. Also the penalty given car start from collision point as near as possible. This is the reason why respawning two cars side by side at the same check point does make sense.)
 
1. f0ac5962f435103e7d6d7cf7a16c745ac31f0a53 -> bug fix of respawning of 2nd car in H2H mode
2. cf6ee607e801d19d7c6e94ab4ae9de6f58a39b13 -> big fix of checking finish line of 2nd car
3. 343b3322a84aff556dac7684bcee4c87498f8dbe -> bug fix of v2's front camera image resolution by comment out of original code  (Maybe better remove the comment out codes)
4. b2910b63380485296b8f8ef448319fb57e6bd882 -> a bit complicate but it has the proposal of putting two cars side by side by calculating the car width and also prevents repeated collision during the respawning time.

This PR doesn't have impact on single time trial mode racing.